### PR TITLE
fix(nginx): updated script for unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,14 +44,12 @@ COPY --from=builder /app/nginx/nginx.conf /etc/nginx/templates/default.conf.temp
 
 # implement changes required to run NGINX as an unprivileged user
 RUN sed -i '/user  nginx;/d' /etc/nginx/nginx.conf \
-    && sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
+    && sed -i 's,\(/var\)\{0\,1\}/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
 # nginx user must own the cache and etc directory to write cache and tweak the nginx config
     && chown -R nginx /var/cache/nginx \
     && chmod -R g+w /var/cache/nginx \
     && chown -R nginx /etc/nginx \
-    && chmod -R g+w /etc/nginx \
-# change the placeholder js file in html
-    && chown -R nginx /usr/share/nginx/html
+    && chmod -R g+w /etc/nginx
 
 USER nginx
 


### PR DESCRIPTION
* updated script to make the user nginx unprivileged in the dockerfile
* changes likely to relate to nginx v1.28
* url: https://github.com/nginx/docker-nginx-unprivileged/blob/main/Dockerfile-alpine-slim.template